### PR TITLE
Added fields to enhance mapping and filtering possibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-[0.1.0]
+## [0.1.0]
 
 - First release
 
+## [0.2.0]
+
+### Added
+
+- added additional properties `variable` and `perturbed` on item/asset level to allow more fine grained filtering of objects
+
 [Unreleased]: <https://github.com/stac-extensions/forecast/compare/v0.1.0...HEAD>
 [0.1.0]: <https://github.com/stac-extensions/forecast/tree/v0.1.0>
+[0.2.0]: <https://github.com/stac-extensions/forecast/compare/v0.1.0...v0.2.0>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The fields in the table below can be used in these parts of STAC documents:
 | forecast:reference_datetime  | string | **REQUIRED.** The *reference* datetime: i.e. predictions for times after this point occur in the future. Predictions prior to this time represent 'hindcasts', predicting states that have already occurred. This must be in UTC. It is formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | forecast:horizon             | string | The time between the reference datetime and the forecast datetime. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT6H` for a 6-hour forecast. |
 | forecast:duration            | string | If the forecast is not only for a specific instance in time but instead is for a certain period, you can specify the length here. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT3H` for a 3-hour accumulation. If not given, assumes that the forecast is for an instance in time as if this was set to `PT0S` (0 seconds). |
+| forecast:param               | string | Name of the model parameter that corresponds to the data, e.g. `T` (temperature), `P` (pressure), `U`/`V`/`W` (windspeed in three directions). |
+| forecast:mode                | string | Denotes whether the data corresponds to the control run or perturbed runs. Allowed values are `ctrl` or `perturb`. |
+| forecast:member              | integer | Specifies the member (sample number) of perturbed runs, e.g. `1`. |
+| forecast:level               | integer | Index of the vertical level of the height coordinate system used in the forecast model, e.g. `4`. |
 
 ### Additional Fields from other extensions
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ The fields in the table below can be used in these parts of STAC documents:
 | forecast:reference_datetime  | string | **REQUIRED.** The *reference* datetime: i.e. predictions for times after this point occur in the future. Predictions prior to this time represent 'hindcasts', predicting states that have already occurred. This must be in UTC. It is formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | forecast:horizon             | string | The time between the reference datetime and the forecast datetime. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT6H` for a 6-hour forecast. |
 | forecast:duration            | string | If the forecast is not only for a specific instance in time but instead is for a certain period, you can specify the length here. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT3H` for a 3-hour accumulation. If not given, assumes that the forecast is for an instance in time as if this was set to `PT0S` (0 seconds). |
-| forecast:parameter           | string | Name of the model parameter that corresponds to the data. The parameters should correspond to the [CF Standard Names](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html), e.g. `air_temperature` for the air temperature. |
+| forecast:variable           | string | Name of the model variable that corresponds to the data. The variables should correspond to the [CF Standard Names](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html), e.g. `air_temperature` for the air temperature. |
 | forecast:perturbed           | boolean | Denotes whether the data corresponds to the control run (`false`) or perturbed runs (`true`). The property needs to be specified in both cases as no default value is specified and as such the meaning is "unknown" in case it's missing. |
 
-`forecast:parameter` is primarily intended for search and as such can only be set to a single value, either on the Asset level or on the Item property level. If this field is insufficient for your usecase, please use the more advanced [CF extension](https://github.com/stac-extensions/cf) instead.
+`forecast:variable` is primarily intended for search and as such can only be set to a single value,
+either on the Asset level or on the Item property level. If this field is insufficient for your usecase,
+please use the more advanced [CF extension](https://github.com/stac-extensions/cf) instead.
 
 ### Additional Fields from other extensions
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ The fields in the table below can be used in these parts of STAC documents:
 | forecast:reference_datetime  | string | **REQUIRED.** The *reference* datetime: i.e. predictions for times after this point occur in the future. Predictions prior to this time represent 'hindcasts', predicting states that have already occurred. This must be in UTC. It is formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | forecast:horizon             | string | The time between the reference datetime and the forecast datetime. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT6H` for a 6-hour forecast. |
 | forecast:duration            | string | If the forecast is not only for a specific instance in time but instead is for a certain period, you can specify the length here. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT3H` for a 3-hour accumulation. If not given, assumes that the forecast is for an instance in time as if this was set to `PT0S` (0 seconds). |
-| forecast:param               | string | Name of the model parameter that corresponds to the data, e.g. `T` (temperature), `P` (pressure), `U`/`V`/`W` (windspeed in three directions). |
-| forecast:mode                | string | Denotes whether the data corresponds to the control run or perturbed runs. Allowed values are `ctrl` or `perturb`. |
+| forecast:parameter           | string | Name of the model parameter that corresponds to the data. The parameters should correspond to the [CF Standard Names](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html), e.g. `air_temperature` for the air temperature. |
+| forecast:perturbed           | boolean | Denotes whether the data corresponds to the control run (`false`) or perturbed runs (`true`). The property needs to be specified in both cases as no default value is specified and as such the meaning is "unknown" in case it's missing. |
 | forecast:member              | integer | Specifies the member (sample number) of perturbed runs, e.g. `1`. |
 | forecast:level               | integer | Index of the vertical level of the height coordinate system used in the forecast model, e.g. `4`. |
+
+`forecast:parameter` is primarily intended for search and as such can only be set to a single value, either on the Asset level or on the Item property level. If this field is insufficient for your usecase, please use the more advanced [CF extension](https://github.com/stac-extensions/cf) instead.
 
 ### Additional Fields from other extensions
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ The fields in the table below can be used in these parts of STAC documents:
 | forecast:duration            | string | If the forecast is not only for a specific instance in time but instead is for a certain period, you can specify the length here. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT3H` for a 3-hour accumulation. If not given, assumes that the forecast is for an instance in time as if this was set to `PT0S` (0 seconds). |
 | forecast:parameter           | string | Name of the model parameter that corresponds to the data. The parameters should correspond to the [CF Standard Names](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html), e.g. `air_temperature` for the air temperature. |
 | forecast:perturbed           | boolean | Denotes whether the data corresponds to the control run (`false`) or perturbed runs (`true`). The property needs to be specified in both cases as no default value is specified and as such the meaning is "unknown" in case it's missing. |
-| forecast:member              | integer | Specifies the member (sample number) of perturbed runs, e.g. `1`. |
-| forecast:level               | integer | Index of the vertical level of the height coordinate system used in the forecast model, e.g. `4`. |
 
 `forecast:parameter` is primarily intended for search and as such can only be set to a single value, either on the Asset level or on the Item property level. If this field is insufficient for your usecase, please use the more advanced [CF extension](https://github.com/stac-extensions/cf) instead.
 

--- a/examples/item.json
+++ b/examples/item.json
@@ -7,6 +7,8 @@
     "grib:discipline": "meteorological",
     "forecast:reference_datetime": "2022-08-12T00:00:00Z",
     "forecast:horizon": "PT0H",
+    "forecast:parameter": "air_temperature",
+    "forecast:perturbed": false,
     "processing:facility": "US-NCEP",
     "proj:epsg": null,
     "proj:projjson": {

--- a/examples/item.json
+++ b/examples/item.json
@@ -7,7 +7,7 @@
     "grib:discipline": "meteorological",
     "forecast:reference_datetime": "2022-08-12T00:00:00Z",
     "forecast:horizon": "PT0H",
-    "forecast:parameter": "air_temperature",
+    "forecast:variable": "air_temperature",
     "forecast:perturbed": false,
     "processing:facility": "US-NCEP",
     "proj:epsg": null,

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -123,7 +123,7 @@
           }
         },
         {
-          "$comment": "This is the schema for the fields in Summaries. By default, only checks the existance of the properties, but not the schema of the summaries.",
+          "$comment": "This is the schema for the fields in Summaries. By default, only checks the existence of the properties, but not the schema of the summaries.",
           "required": [
             "summaries"
           ],
@@ -152,7 +152,7 @@
       }
     },
     "require_any_field": {
-      "$comment": "Please list all fields here so that we can force the existance of one of them in other parts of the schemas.",
+      "$comment": "Please list all fields here so that we can force the existence of one of them in other parts of the schemas.",
       "anyOf": [
         {"required": ["forecast:reference_datetime"]},
         {"required": ["forecast:horizon"]},
@@ -169,12 +169,19 @@
         },
         "forecast:horizon": {
           "type": "string",
-          "$comment": "suration format is not supported in draft 07, should we upgrade the schema to draft 2019-09?",
+          "$comment": "duration format is not supported in draft 07, should we upgrade the schema to draft 2019-09?",
           "format": "duration"
         },
         "forecast:duration": {
           "type": "string",
           "format": "duration"
+        },
+        "forecast:parameter": {
+          "type": "string",
+          "$comment": "we cannot make a strict validation on the value but it should be from the cf standard names list https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html"
+        },
+        "forecast:perturbed": {
+          "type": "boolean"
         }
       },
       "patternProperties": {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -156,7 +156,9 @@
       "anyOf": [
         {"required": ["forecast:reference_datetime"]},
         {"required": ["forecast:horizon"]},
-        {"required": ["forecast:duration"]}
+        {"required": ["forecast:duration"]},
+        {"required": ["forecast:variable"]},
+        {"required": ["forecast:perturbed"]}
       ]
     },
     "fields": {
@@ -176,7 +178,7 @@
           "type": "string",
           "format": "duration"
         },
-        "forecast:parameter": {
+        "forecast:variable": {
           "type": "string",
           "$comment": "we cannot make a strict validation on the value but it should be from the cf standard names list https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html"
         },


### PR DESCRIPTION
Besides it's original intention (satellite data), STAC and STAC API proved to be useful for many other data having a georeference of some kind as well. For many of them the core specification of STAC and STAC API is sufficient. In case of weather forecast data, there are limitations however due to the vast amount of data, the frequent update cycles and the nature of the data. 

Weather forecast data is typically calculated or recalculated every X hours (e.g. 3h) and results conceptually in a large number of datapackages, each containing the result of a specific selection of parameters among the many degrees of freedom (spatial, temporal, others...). The fields offered by STAC core allow to distinguish spatial and temporal parameters, but not more. Mapping these > 100'000 datapackages to STAC would either mean few items with an extensive list of assets, or a large list of items with one or a few assets each, or combining several parameter combinations in one file and having large files (50GB +). Each of these solutions is not very user-friendly, since selecting a subset of the data is hard to impossible (E.g. the spatial extent is often the same for every datapackage (covering the whole weather model grid) so it's of limited use for e.g. filtering).

We propose to add additional fields to the forecast extension to enhance mapping and filtering possibilities for forecast data. The degrees of freedom the data contains are
- 2D extent of the model grid
- datetime when the data was calculated
- datetime in the future to which the forecast corresponds
- level (third spatial dimension, mostly just an index)
- physical parameter (temperature, pressure etc.)
- perturbation sample

Open questions:
- We have implemented the query extension (https://github.com/stac-api-extensions/query, https://data.geo.admin.ch/api/stac/static/spec/v0.9/apitransactional.html#tag/STAC/operation/postSearchSTAC) so basically we are able to filter on these attributes as well.
- `forecast:param` can be a `string` or a list or strings. Having just a string would mean each parameter has to be in a separate file, having a list of strings would allow to combine parameters in one file. Although a more practical scenario is probably rather to just have a few parameter groups, e.g. "surface" or "full atmosphere" parameter group which could be implemented with just a `string`. Having just `string`s and not lists is also easier for querying/filtering the data, so we propose to just have strings. The allowed values for `forecast:param` are intentionally unrestricted since these heavily depend on the forecast model configuration.
- As for perturbation: users are often either interested in either the control run or all of the perturbation runs. For this it would be sufficient to have a `forecast:mode` attribute with values of either `ctrl` or `perturb`. If desired/necessary it could be paired with a `forecast:sample_nr` with the number of the perturbation run. Since we'll not currently use this it can also be omitted for now and added later if there's a usecase for it.
- The `forecast:level` will also not be implemented/used in our usecase, but could be useful for others.