### PR TITLE
Additional fields from #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The fields in the table below can be used in these parts of STAC documents:
 | forecast:reference_datetime  | string | **REQUIRED.** The *reference* datetime: i.e. predictions for times after this point occur in the future. Predictions prior to this time represent 'hindcasts', predicting states that have already occurred. This must be in UTC. It is formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | forecast:horizon             | string | The time between the reference datetime and the forecast datetime. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT6H` for a 6-hour forecast. |
 | forecast:duration            | string | If the forecast is not only for a specific instance in time but instead is for a certain period, you can specify the length here. Formatted as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `PT3H` for a 3-hour accumulation. If not given, assumes that the forecast is for an instance in time as if this was set to `PT0S` (0 seconds). |
+| forecast:member              | integer | Specifies the member (sample number) of perturbed runs, e.g. `1`. |
+| forecast:level               | integer | Index of the vertical level of the height coordinate system used in the forecast model, e.g. `4`. |
 
 ### Additional Fields from other extensions
 


### PR DESCRIPTION
Two additional fields originally proposed in #12, split apart for further discussion.

- forecast:member: Should probably only apply if preturbed is true, implies 0 for pretured = false. That means minimum is 1.
- forecast:level: Do we know which height coordinate system is used? Otherwise, this value seems pretty ambiguous. So maybe either add a property to set the CRS or add a link relation type that points to documentation that defines these levels.